### PR TITLE
Support multiple resource types download

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,15 @@ good to go.
 If you're on Windows, [cygwin](http://www.cygwin.com/) may be your best
 bet.
 
+If you want to fetch resources other than Alexa's top HTMLs, you can do
+that by doing something like `cat resource_urls.txt | ./downloadr.py`
+
 ## Dependencies
 
 * Python (Tested with 2.7)
 * curl
 * zcat
+* [python-magic](https://github.com/ahupp/python-magic)
 
 ## Results 
 
@@ -34,5 +38,4 @@ verify there are not toom many files in a single directory.
 
 The resulting files have an ".html.txt" extension for the data files and
 ".html.hdr.txt" extension for the header files.
-
 

--- a/downloadr.py
+++ b/downloadr.py
@@ -4,16 +4,16 @@ import os
 from time import gmtime, strftime
 import sys
 from urllib2 import HTTPError, URLError, urlopen
-from multiprocessing.pool import ThreadPool
 import hashlib
 import magic
 
-curdate = "webdevdata.org-" + strftime("%Y-%m-%d-%H%M%S", gmtime())
-os.mkdir(curdate)
-os.chdir(curdate)
-pool = ThreadPool(processes = 64)
+def createDir():
+    dirname = "webdevdata.org-" + strftime("%Y-%m-%d-%H%M%S", gmtime())
+    os.mkdir(dirname)
+    return dirname
 
-def downloadFile(url):
+def downloadFile(url, dir):
+    os.chdir(dir)
     url = url.strip()
     try: 
         print "Downloading: ", url
@@ -43,8 +43,17 @@ def downloadFile(url):
     except URLError, e:
         print "URLError:", e.reason, url
 
-for url in sys.stdin.xreadlines():
-    pool.map_async(downloadFile, [url, ])
-
-pool.close()
-pool.join()
+if __name__=="__main__":
+    if len(sys.argv) < 2:
+        print >>sys.stderr, "Usage:", sys.argv[0], "create|download", "<URL>", "<dir>"
+        quit()
+    command = sys.argv[1]
+    if command == "create":
+        print createDir()
+    elif command == "download":
+        if len(sys.argv) < 4:
+            print >>sys.stderr, "Where's the URL and the directory?"
+            quit()
+        downloadFile(sys.argv[2], sys.argv[3])
+    else:
+        print >>sys.stderr, "Didn't understand the command", command

--- a/getData.sh
+++ b/getData.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 
-curl http://s3.amazonaws.com/alexa-static/top-1m.csv.zip | zcat | awk -F',' '{print $2}' > /tmp/urls.txt
-cat /tmp/urls.txt | ./downloadr.py
+URLS=/tmp/urls.txt
+if [ ! -f $URLS ] 
+then
+    curl http://s3.amazonaws.com/alexa-static/top-1m.csv.zip | zcat | awk -F',' '{print $2}' > $URLS
+fi
+DIR=`./downloadr.py create`
+cat $URLS | xargs -I{} -n 1 -P64 ./downloadr.py download {} $DIR


### PR DESCRIPTION
I've added support for multiple resource types to the downloadr script. My goal was to enable download of image resources for further analysis, but it can be used for other resources as well.

The default "./getData.sh" script is not changed and still downloads only homepage HTMLs.
